### PR TITLE
feat: add dependency update flag

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7003,6 +7003,7 @@ const main = async () => {
     // TODO: add repo
     // TODO: init in case Helm2
     const helm = await helm_1.Helm.create();
+    const dependencyUpdate = (0, core_1.getInput)('dependencyUpdate', { required: false });
     const namespace = (0, core_1.getInput)('namespace', { required: true });
     const releaseName = (0, core_1.getInput)('releaseName', { required: true });
     const wait = (0, core_1.getInput)('wait', { required: false });
@@ -7034,6 +7035,9 @@ const main = async () => {
         releaseName,
         chart,
     ];
+    if (String(dependencyUpdate) === 'true') {
+        helmArgs.push('--dependency-update');
+    }
     if (wait != 'false') {
         helmArgs.push('--wait');
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k8s-deployer-action",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/main.d.ts",

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ const main = async (): Promise<void> => {
 
   const helm = await Helm.create();
 
+  const dependencyUpdate = getInput('dependencyUpdate', { required: false });
   const namespace = getInput('namespace', { required: true });
   const releaseName = getInput('releaseName', { required: true });
   const wait = getInput('wait', { required: false });
@@ -104,6 +105,10 @@ const main = async (): Promise<void> => {
     releaseName,
     chart,
   ];
+
+  if (String(dependencyUpdate) === 'true') {
+    helmArgs.push('--dependency-update');
+  }
 
   if (wait != 'false') {
     helmArgs.push('--wait');


### PR DESCRIPTION
I created a [library chart](https://helm.sh/docs/topics/library_charts/) for the ds-api repo that will contain shared templates for different services of ours but to use it I have to either run `helm dependency update my-chart` for ever chart we have or I can upgrade with `--dependency-update` flag. I guess the other approach is more automatic, so I'd like to update the action to have this option