### PR TITLE
fix(action.yaml): add dependencyUpdate flag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,9 @@ inputs:
   wait:
     description: 'Helm --wait flag. Defaults to true'
     required: false
+  dependencyUpdate:
+    description: 'Helm --dependency-update flag for the helm upgrade command. Defaults to false'
+    required: false
 
 runs:
   using: 'node20'


### PR DESCRIPTION
```
Warning: Unexpected input(s) 'dependencyUpdate', valid inputs are ['namespace', 'releaseName', 'chart', 'helmVersion', 'values', 'valueFiles', 'repoUrl', 'repoName', 'wait']
```

Sorry, I didn't know that there's one more place to add the flag. Without it, the above warning is shown in the action. It doesn't break anything though, so I will remove the v3.1.0 tag and recreate it with this change